### PR TITLE
Fixed node.js download URL

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -49,7 +49,7 @@ else
 fi
 
 # Download node from Heroku's S3 mirror of nodejs.org/dist
-node_url="https://nodejs.org/dist/v$node_version/node-v$node_version-linux-x64.tar.xz"
+node_url="https://nodejs.org/dist/v$node_version/node-v$node_version-linux-x64.tar.gz"
 status "Downloading and installing node from $node_url"
 curl $node_url -s -o - | tar xzf - -C $build_dir
 

--- a/bin/compile
+++ b/bin/compile
@@ -49,8 +49,8 @@ else
 fi
 
 # Download node from Heroku's S3 mirror of nodejs.org/dist
-status "Downloading and installing node"
 node_url="https://nodejs.org/dist/$node_version/node-v$node_version-linux-x64.tar.gz"
+status "Downloading and installing node from $node_version"
 curl $node_url -s -o - | tar xzf - -C $build_dir
 
 # Move node (and npm) into ./vendor and make them executable

--- a/bin/compile
+++ b/bin/compile
@@ -50,7 +50,7 @@ fi
 
 # Download node from Heroku's S3 mirror of nodejs.org/dist
 node_url="https://nodejs.org/dist/$node_version/node-v$node_version-linux-x64.tar.gz"
-status "Downloading and installing node from $node_version"
+status "Downloading and installing node from $node_url"
 curl $node_url -s -o - | tar xzf - -C $build_dir
 
 # Move node (and npm) into ./vendor and make them executable

--- a/bin/compile
+++ b/bin/compile
@@ -49,7 +49,7 @@ else
 fi
 
 # Download node from Heroku's S3 mirror of nodejs.org/dist
-node_url="https://nodejs.org/dist/$node_version/node-v$node_version-linux-x64.tar.gz"
+node_url="https://nodejs.org/dist/v$node_version/node-v$node_version-linux-x64.tar.xz"
 status "Downloading and installing node from $node_url"
 curl $node_url -s -o - | tar xzf - -C $build_dir
 

--- a/bin/compile
+++ b/bin/compile
@@ -50,7 +50,7 @@ fi
 
 # Download node from Heroku's S3 mirror of nodejs.org/dist
 status "Downloading and installing node"
-node_url="http://s3pository.heroku.com/node/v$node_version/node-v$node_version-linux-x64.tar.gz"
+node_url="https://nodejs.org/dist/$node_version/node-v$node_version-linux-x64.tar.gz"
 curl $node_url -s -o - | tar xzf - -C $build_dir
 
 # Move node (and npm) into ./vendor and make them executable


### PR DESCRIPTION
Fixed node js download URL as the old one was returning 301 that is not followed by default when using curl.
Also added the URL to the status line to be able to debug it if it fails in the future.